### PR TITLE
Use "Validated" as the CocoaPods module name

### DIFF
--- a/PointFree-Validated.podspec
+++ b/PointFree-Validated.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "PointFree-Validated"
+  s.module_name "Validated"
   s.version = "0.1.1"
   s.summary = "A result type that accumulates multiple errors."
 


### PR DESCRIPTION
Didn't realize it would default to `import PointFree_Validated`.