### PR TITLE
Prep 0.2.1

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "pointfreeco/swift-nonempty" ~> 0.2.0
+github "pointfreeco/swift-nonempty" ~> 0.2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "pointfreeco/swift-nonempty" "0.2.0"
+github "pointfreeco/swift-nonempty" "0.2.1"

--- a/PointFree-Validated.podspec
+++ b/PointFree-Validated.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "PointFree-Validated"
   s.module_name = "Validated"
-  s.version = "0.2.0"
+  s.version = "0.2.1"
   s.summary = "A result type that accumulates multiple errors."
 
   s.description = <<-DESC
@@ -32,5 +32,5 @@ Pod::Spec.new do |s|
 
   s.source_files  = "Sources", "Sources/**/*.swift"
 
-  s.dependency "NonEmpty", "~> 0.2.0"
+  s.dependency "NonEmpty", "~> 0.2.1"
 end

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Invalid errors are held in a [non-empty array](https://github.com/pointfreeco/sw
 If you use [Carthage](https://github.com/Carthage/Carthage), you can add the following dependency to your `Cartfile`:
 
 ``` ruby
-github "pointfreeco/swift-validated" ~> 0.2
+github "pointfreeco/swift-validated" ~> 0.2.1
 ```
 
 ### CocoaPods
@@ -179,7 +179,7 @@ github "pointfreeco/swift-validated" ~> 0.2
 If your project uses [CocoaPods](https://cocoapods.org), just add the following to your `Podfile`:
 
 ``` ruby
-pod 'PointFree-Validated', '~> 0.2'
+pod 'PointFree-Validated', '~> 0.2.1'
 ```
 
 ### SwiftPM
@@ -188,7 +188,7 @@ If you want to use Validated in a project that uses [SwiftPM](https://swift.org/
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-validated.git", from: "0.2.0")
+  .package(url: "https://github.com/pointfreeco/swift-validated.git", from: "0.2.1")
 ]
 ```
 


### PR DESCRIPTION
Validated depends on NonEmpty, which is broken. While I think `~>` rules should pull down the bug fix bump, this should force resolution to 0.2.1.

Diff: https://github.com/pointfreeco/swift-validated/compare/0.2.0...prep-0-2-1